### PR TITLE
perf(mssql): enable OPTIMIZE_FOR_SEQUENTIAL_KEY on primary keys for S…

### DIFF
--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -10,7 +10,7 @@ IF OBJECT_ID('__schema__.Streams', 'U') IS NULL
             StreamId   INT IDENTITY (1,1) NOT NULL,
             StreamName NVARCHAR(850)      NOT NULL,
             [Version]  INT DEFAULT (-1)   NOT NULL,
-            CONSTRAINT PK_Streams PRIMARY KEY CLUSTERED (StreamId),
+            CONSTRAINT PK_Streams PRIMARY KEY CLUSTERED (StreamId) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON),
             CONSTRAINT UQ_StreamName UNIQUE NONCLUSTERED (StreamName),
             CONSTRAINT CK_VersionGteNegativeOne CHECK ([Version] >= -1)
         );
@@ -28,7 +28,7 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             JsonData       NVARCHAR(MAX)         NOT NULL,
             JsonMetadata   NVARCHAR(MAX)         NOT NULL,
             Created        DATETIME2(7)          NOT NULL,
-            CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
+            CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),
             CONSTRAINT UQ_StreamIdAndMessageId UNIQUE NONCLUSTERED (StreamId, MessageId),


### PR DESCRIPTION
perf(mssql): enable OPTIMIZE_FOR_SEQUENTIAL_KEY on primary keys for Streams and Messages
- Added WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON) to clustered primary keys on __schema__.Streams (PK_Streams) and __schema__.Messages (PK_Events)
- Improves insert throughput and reduces latch contention on identity-based keys
- No changes to schema shape, constraints, or indexes beyond PK optimization

This improves concurrent insert performance under high write workloads by allowing SQL Server to better handle last-page insert contention on sequential identity keys.
See docs on OPTIMIZE_FOR_SEQUENTIAL_KEY: https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-index-option-transact-sql?view=sql-server-ver17#optimize_for_sequential_key---on--off-