### PR TITLE
feat(sql): make append_events atomic and improve concurrency handling

### DIFF
--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -1,30 +1,41 @@
 CREATE OR ALTER PROCEDURE __schema__.append_events
-    @stream_name VARCHAR(850),
+    @stream_name NVARCHAR(850),
     @expected_version INT,
     @created DATETIME2(7) NULL,
     @messages __schema__.StreamMessage READONLY
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    IF NOT EXISTS (SELECT 1 FROM @messages)
+        THROW 50002, N'No messages to append', 1;
 
     DECLARE
         @current_version INT,
         @stream_id INT,
         @position BIGINT,
-        @customErrorMessage NVARCHAR(200);
+        @count_messages INT,
+        @new_version INT;
 
-    IF @created IS NULL
-        BEGIN
-            SET @created = SYSUTCDATETIME();
-        END
+    -- capture inserted rows to compute final position
+    DECLARE @inserted TABLE (
+        GlobalPosition BIGINT
+    );
 
-    EXEC [__schema__].check_stream
-        @stream_name      = @stream_name,
-        @expected_version = @expected_version,
-        @current_version  = @current_version OUTPUT,
-        @stream_id        = @stream_id OUTPUT;
+    SELECT @count_messages = COUNT(1) FROM @messages;
 
     BEGIN TRY
+        BEGIN TRANSACTION;
+
+        EXEC __schema__.check_stream
+            @stream_name       = @stream_name,
+            @expected_version  = @expected_version,
+            @current_version   = @current_version OUTPUT,
+            @stream_id         = @stream_id OUTPUT;
+
+        SET @new_version = @current_version + @count_messages;
+
         INSERT INTO __schema__.Messages (
             MessageId,
             MessageType,
@@ -34,45 +45,62 @@ BEGIN
             JsonMetadata,
             Created
         )
+        OUTPUT inserted.GlobalPosition
+        INTO @inserted (GlobalPosition)
         SELECT
             message_id,
             message_type,
             @stream_id,
-            @current_version + (ROW_NUMBER() OVER(ORDER BY (SELECT NULL))),
+            @current_version + CAST(ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS INT),
             json_data,
             json_metadata,
-            @created
-        FROM @messages
+            ISNULL(@created, SYSUTCDATETIME())
+        FROM @messages;
+
+        -- If another writer raced us, the unique constraint (StreamId,StreamPosition) will throw here.
+        -- Translate to WrongExpectedVersion.
+        -- (Handled in the CATCH below.)
+
+        UPDATE s
+        SET s.[Version] = @new_version
+        FROM __schema__.Streams s
+        WHERE s.StreamId = @stream_id;
+
+        -- final values to return
+        SELECT @position = (
+            SELECT MAX(GlobalPosition)
+            FROM @inserted
+        );
+
+        COMMIT TRANSACTION;
     END TRY
     BEGIN CATCH
-        IF (ERROR_NUMBER() = 2627 OR ERROR_NUMBER() = 2601) AND (SELECT CHARINDEX(N'UQ_StreamIdAndStreamPosition', ERROR_MESSAGE())) > 0
-            BEGIN
-                DECLARE @streamIdFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()), PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) - PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()))
-                DECLARE @streamPositionFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE())) + 2, PATINDEX(N'%).', ERROR_MESSAGE()) - (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) + 2))
+        IF XACT_STATE() <> 0 ROLLBACK;
 
-                -- TODO: There are multiple causes of OptimisticConcurrencyExceptions, but current client code is hard-coded to check for 'WrongExpectedVersion' in message and 50000 as error number.
-                SELECT @customErrorMessage = FORMATMESSAGE(N'WrongExpectedVersion, another message has already been written at stream position %s on stream %s.', @streamIdFromError, @streamPositionFromError);
-                THROW 50000, @customErrorMessage, 1;
-            END;
-        ELSE
+        DECLARE @errmsg  NVARCHAR(2048) = ERROR_MESSAGE();
+
+        IF ERROR_NUMBER() IN (
+            2627, -- Violation of PRIMARY KEY or UNIQUE constraint
+            2601  -- Cannot insert duplicate key row in object with unique index
+        )
+           AND (
+                @errmsg LIKE N'%UQ_StreamIdAndStreamPosition%'
+           )
         BEGIN
-            ;THROW;
+            -- Must BEGIN with "WrongExpectedVersion" for the client detection of OptimisticConcurrencyException
+            DECLARE @clientMsg NVARCHAR(4000) =
+                N'WrongExpectedVersion: duplicate append for stream '
+                + CAST(@stream_id AS NVARCHAR(20))
+                + N' with expected_version=' + CAST(@expected_version AS NVARCHAR(20))
+                + N'. SQL: ' + @errmsg;
+
+            THROW 50000, @clientMsg, 1;
         END;
+
+        ;THROW;
     END CATCH;
 
-    SELECT TOP (1)
-        @current_version = StreamPosition,
-        @position = GlobalPosition
-    FROM __schema__.Messages
-    WHERE StreamId = @stream_id
-    ORDER BY GlobalPosition DESC;
-
-    UPDATE s
-    SET [Version] = @current_version
-    FROM __schema__.Streams s
-    WHERE s.StreamId = @stream_id;
-
     SELECT
-        @current_version current_version,
+        @new_version current_version,
         @position position;
 END;


### PR DESCRIPTION
- Wrapped append_events logic in a single transaction with SET XACT_ABORT ON
- Changed @stream_name parameter to NVARCHAR(850) for consistency
- Added guard clause for empty @messages
- Introduced @inserted table to capture inserted GlobalPosition values atomically
- Updated Streams.[Version] within the same transaction
- Normalized optimistic concurrency errors (2627, 2601) to client-detectable messages
- Thrown error messages still StartsWith 'WrongExpectedVersion' but now also includes the full SQL error text for client tracing
- Removed redundant post-commit queries and error-parsing logic

Fixes issue #429